### PR TITLE
prevent segfault in `get` if table is null

### DIFF
--- a/tests/test.odin
+++ b/tests/test.odin
@@ -1,0 +1,13 @@
+package tests
+
+import "core:testing"
+
+import toml ".."
+
+@(test)
+nil_guard_get :: proc(t: ^testing.T) {
+	table: toml.Table
+
+	_, found := toml.get_bool(&table, "enabled")
+	testing.expectf(t, found == false, "should not crash on nullptr exception not found")
+}

--- a/toml.odin
+++ b/toml.odin
@@ -23,9 +23,13 @@ parse_data :: proc(data: []u8, original_filename := "untitled data", allocator :
 // Retrieves and type checks the value at path. The last element of path is the actual key.
 //section may be any Table.
 get :: proc($T: typeid, section: ^Table, path: ..string) -> (val: T, ok: bool)
-    where intrinsics.type_is_variant_of(Type, T) 
+    where intrinsics.type_is_variant_of(Type, T)
 {
     assert(len(path) > 0, "You must specify at least one path str in toml.fetch()!")
+	if section == nil {
+		return val, false
+	}
+
     section := section
     for dir in path[:len(path) - 1] {
         if dir in section {


### PR DESCRIPTION
I have some code where I want to merge multiple tables, and I ended up doing something like:
```odin
global: ^toml.Table
local: ^toml.Table 

try_load_config(&global, ...)
try_load_config(&local, ...)

configuration.enabled = get_key(bool, global, local, "enabled")
```
And it makes the high-level code nicer if this is handled internally in the lib.