### PR TITLE
Fix printing local dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 testing
 compile.sh
 ols.json
+/toml_parser

--- a/dates/parser.odin
+++ b/dates/parser.odin
@@ -1,6 +1,7 @@
 package dates
 
 import "core:fmt"
+import "core:math"
 import "core:slice"
 import "core:strconv"
 import "core:strings"
@@ -187,18 +188,22 @@ partial_date_to_string :: proc(date: Date, time_sep := ' ',) -> (out: string, er
     b: strings.Builder
     strings.builder_init_len_cap(&b, 0, 25)
 
+	_, frac := math.modf_f32(date.second)
+	timefmt := "%02d:%02d:%02.0f"
+	if frac > 0  do timefmt = "%02d:%02d:%06.03f"
+
     if date.is_date_only {
         fmt.sbprintf(&b, "%04d-%02d-%02d", date.year, date.month, date.day)
         return strings.to_string(b), .NONE
     }
     if date.is_time_only {
-        fmt.sbprintf(&b, "%02d:%02d:%02.0f", date.hour, date.minute, date.second)
+        fmt.sbprintf(&b, timefmt, date.hour, date.minute, date.second)
         return strings.to_string(b), .NONE
     }
 
-    fmt.sbprintf(&b, "%04d-%02d-%02d%c%02d:%02d:%02.0f",
-        date.year, date.month, date.day, time_sep,
-        date.hour, date.minute, date.second)
+    fmt.sbprintf(&b, "%04d-%02d-%02d", date.year, date.month, date.day)
+    strings.write_rune(&b, time_sep)
+	fmt.sbprintf(&b, timefmt, date.hour, date.minute, date.second)
 
     if date.is_date_local do return strings.to_string(b), .NONE
 

--- a/main.odin
+++ b/main.odin
@@ -42,11 +42,8 @@ main :: proc() {
 
     table, err := parse(string(data[:count]), "<stdin>")
 
-    if any_of("--print-errors", ..os.args) && err.type != .None { logln(err); print_error(err) }
-    if err.type != .None do os.exit(1) 
+    if err.type != .None { print_error(err); os.exit(1) }
 
-    // if err.type != .None do logln(err)
-    
     idk,  ok := marshal(table)
     if !ok do return
     json, _ := json.marshal(idk)


### PR DESCRIPTION
Previously it would print a trailing "TZ":

	% ./toml_parser <<<a=2012-02-03
	{"a":{"type":"date-local","value":"2012-02-03TZ"}}

Simplify the logic a bit to just return early for local-date and
local-time.

---

Also a second commit to always print the error on for toml_parser, which seems useful to me?